### PR TITLE
Remove unnecessary yarnrc

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-workspaces-experimental true


### PR DESCRIPTION
Yarn Workspace is not an experimental feature anymore so there's no need for this file.